### PR TITLE
Moves defer block with geometriesPointer dealloc

### DIFF
--- a/GEOSwift/Geometries.swift
+++ b/GEOSwift/Geometries.swift
@@ -118,7 +118,9 @@ open class Polygon : Geometry {
                 let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.geometry)
                 geometriesPointer?[i] = GEOSGeom
             }
-            defer {
+        }
+        defer {
+            if let holes = holes, holes.count > 0 {
                 geometriesPointer?.deallocate(capacity: holes.count)
             }
         }


### PR DESCRIPTION
The defer block that holds the call to geometriesPointer.dealloc gets called before the pointer can be used when the geometry contains holes. This causes the creation of geometry that has holes to fail.